### PR TITLE
Recording support for Android (Java side)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
   android:installLocation="auto" xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
+  <uses-permission android:name="android.permission.RECORD_AUDIO" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 

--- a/love/src/main/java/org/love2d/android/DownloadActivity.java
+++ b/love/src/main/java/org/love2d/android/DownloadActivity.java
@@ -13,7 +13,7 @@ import android.util.Log;
 import androidx.core.app.ActivityCompat;
 
 public class DownloadActivity extends Activity {
-    public static final int EXTERNAL_STORAGE_REQUEST_CODE = 2;
+    public static final int EXTERNAL_STORAGE_REQUEST_CODE = 3;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/love/src/main/java/org/love2d/android/GameActivity.java
@@ -34,7 +34,9 @@ public class GameActivity extends SDLActivity {
     private static Context context;
     private static Vibrator vibrator = null;
     protected final int[] externalStorageRequestDummy = new int[1];
+    protected final int[] recordAudioRequestDummy = new int[1];
     public static final int EXTERNAL_STORAGE_REQUEST_CODE = 1;
+    public static final int RECORD_AUDIO_REQUEST_CODE = 2;
     private static boolean immersiveActive = false;
     private static boolean mustCacheArchive = false;
     private boolean storagePermissionUnnecessary = false;
@@ -396,6 +398,16 @@ public class GameActivity extends SDLActivity {
         return audioManager.isMusicActive();
     }
 
+    @Keep
+    public void showRecordingAudioPermissionMissingDialog() {
+        AlertDialog dialog = new AlertDialog.Builder(mSingleton)
+            .setTitle("Audio Recording Permission Missing")
+            .setMessage("It appears that this game request for mic permission. The game may not work correctly without mic permission!")
+            .setNeutralButton("Continue", null)
+            .create();
+        dialog.show();
+    }
+
     public void showExternalStoragePermissionMissingDialog() {
         AlertDialog dialog = new AlertDialog.Builder(mSingleton)
             .setTitle("Storage Permission Missing")
@@ -412,22 +424,39 @@ public class GameActivity extends SDLActivity {
         if (grantResults.length > 0) {
             Log.d("GameActivity", "Received a request permission result");
 
-            if (requestCode == EXTERNAL_STORAGE_REQUEST_CODE) {
-                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    Log.d("GameActivity", "Permission granted");
-                } else {
-                    Log.d("GameActivity", "Did not get permission.");
-                    if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-                        showExternalStoragePermissionMissingDialog();
+            switch (requestCode) {
+                case EXTERNAL_STORAGE_REQUEST_CODE: {
+                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        Log.d("GameActivity", "Permission granted");
+                    } else {
+                        Log.d("GameActivity", "Did not get permission.");
+                        if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                            showExternalStoragePermissionMissingDialog();
+                        }
                     }
-                }
 
-                Log.d("GameActivity", "Unlocking LÖVE thread");
-                synchronized (externalStorageRequestDummy) {
-                    externalStorageRequestDummy[0] = grantResults[0];
-                    externalStorageRequestDummy.notify();
+                    Log.d("GameActivity", "Unlocking LÖVE thread");
+                    synchronized (externalStorageRequestDummy) {
+                        externalStorageRequestDummy[0] = grantResults[0];
+                        externalStorageRequestDummy.notify();
+                    }
+                    break;
                 }
-           }
+                case RECORD_AUDIO_REQUEST_CODE: {
+                    if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                        Log.d("GameActivity", "Mic ermission granted");
+                    } else {
+                        Log.d("GameActivity", "Did not get mic permission.");
+                    }
+
+                    Log.d("GameActivity", "Unlocking LÖVE thread");
+                    synchronized (recordAudioRequestDummy) {
+                        recordAudioRequestDummy[0] = grantResults[0];
+                        recordAudioRequestDummy.notify();
+                    }
+                    break;
+                }
+            }
         }
     }
 
@@ -452,6 +481,49 @@ public class GameActivity extends SDLActivity {
         }
 
         return ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @Keep
+    public boolean hasRecordAudioPermission() {
+        if (ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED) {
+            return true;
+        }
+
+        Log.d("GameActivity", "Requesting mic permission and locking LÖVE thread until we have an answer.");
+        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
+
+        synchronized (recordAudioRequestDummy) {
+            try {
+                recordAudioRequestDummy.wait();
+            } catch (InterruptedException e) {
+                Log.d("GameActivity", "requesting mic permission", e);
+                return false;
+            }
+        }
+
+        return ActivityCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    @Keep
+    public void requestRecordAudioPermission() {
+        if (ActivityCompat.checkSelfPermission(this,
+                Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        Log.d("GameActivity", "Requesting mic permission and locking LÖVE thread until we have an answer.");
+        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
+
+        synchronized (recordAudioRequestDummy) {
+            try {
+                recordAudioRequestDummy.wait();
+            } catch (InterruptedException e) {
+                Log.d("GameActivity", "requesting mic permission", e);
+            }
+        }
     }
 
     @Keep


### PR DESCRIPTION
This pull request adds support of recording capabilities to Android, which includes requesting the permission and prompt it to user.

The changes (including C++ side PR)

1. It reads `t.audio.mic` configuration in `conf.lua` and store it somewhere.
2. When `love.audio` is loaded, it reads the value of `t.audio.mic` previously set.
3. When `t.audio.mic` is true, it requests mic permission. The result is used later.
4. When `love.audio.getRecordingDevices` is called:
4a. If user denies the permission (incl. ticking "Don't Ask Again"), dialog will be shown to prompt user and this function will return empty list of recording devices.
4b. If user granted the permission, this function will enumerate recording devices as usual.

C++ side PR: https://bitbucket.org/rude/love/pull-requests/126