### PR TITLE
Initialize the LUA_CPATH environment variable to getCRequirePath().

### DIFF
--- a/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/love/src/main/java/org/love2d/android/GameActivity.java
@@ -45,6 +45,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Vibrator;
+import android.system.ErrnoException;
+import android.system.Os;
 import android.util.Log;
 import android.util.DisplayMetrics;
 import android.view.*;
@@ -126,6 +128,12 @@ public class GameActivity extends SDLActivity {
         if (android.os.Build.VERSION.SDK_INT >= 28) {
             getWindow().getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER;
             shortEdgesMode = false;
+        }
+
+        try {
+            Os.setenv("LUA_CPATH", "./?.so;" + getCRequirePath(), true);
+        } catch (ErrnoException e) {
+            Log.d("GameActivity", "Could not set LUA_CPATH: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
In would like to drop foo.so into the applicationInfo.nativeLibraryDir directory (app/src/main/jniLibs/arm64-v8a/) and do ffi.load("foo"). A few years ago this worked fine, but now fails with the error:

    main.lua:6: dlopen failed: library "libfoo.so" not found

When I set the environment variable LUA_CPATH to include getCRequirePath(), LuaJIT is able to find libfoo in package.cpath, and load it properly.

Before:

    package.cpath = ./?.so;/usr/local/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so

After:

    package.cpath = ./?.so;/data/app/~~bA-o3tblNjxoXGxEegyvlQ==/org.love2d.android-B3nOyZj457IR_fUb49FRSw==/lib/arm64/?.so
