### PR TITLE
Permission changes for accessing files on external storage (Android 11+)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
       android:allowBackup="true"
       android:icon="@drawable/love"
       android:label="LÖVE for Android"
-      android:usesCleartextTraffic="true" >
+      android:usesCleartextTraffic="true"
+      android:requestLegacyExternalStorage="true" >
     <activity
         android:name="org.love2d.android.GameActivity"
         android:exported="true"

--- a/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/love/src/main/java/org/love2d/android/GameActivity.java
@@ -119,6 +119,13 @@ public class GameActivity extends SDLActivity {
 
         super.onCreate(savedInstanceState);
         metrics = getResources().getDisplayMetrics();
+        if (Build.VERSION.SDK_INT >= 30) {
+            if (!Environment.isExternalStorageManager()) {
+                Intent getpermission = new Intent();
+                getpermission.setAction(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                startActivity(getpermission);
+            }
+        }
 
         // Set low-latency audio values
         nativeSetDefaultStreamValues(getAudioFreq(), getAudioSMP());


### PR DESCRIPTION
Hi, i've succeeded to access files on external storage in order to use nativefs.lua with nativefs.mount() function.

Tested on device: Redmi 9A (armeabi-v7a) - MIUI 12.5 + Android 11

How it'll work:
-An additional permission is added to app\src\main\AndroidManifest.xml to grant access
-Some code is added to love\src\main\java\org\love2d\android\GameActivity.java to check the aforementioned permission, on first run, Android will pop up the files access permission config to enable LÖVE to access all files, after that, the no-game screen appears. After that point, you can put some code to <internal_storage>/Android/data/org.love2d.android/files/games/lovegame and use nativefs.lua to mount zip files or read any file from internal storage (generally from /storage/emulated/0)

Caveats and reccomendations:
-Since is a (very) sensitive permission, Google Play will reject the app from publishing, so the recommendation is to distribute a Google Play version and either (or both) F-Droid and standalone APK like Total Commander did.