### PR TITLE
Provide App To Select *.love File to Open

### DIFF
--- a/app/src/normal/AndroidManifest.xml
+++ b/app/src/normal/AndroidManifest.xml
@@ -52,5 +52,17 @@
             android:pathPattern=".*\\.love" />
       </intent-filter>
     </activity>
+    <activity
+        android:name="org.love2d.android.SelectorActivity"
+        android:label="LÖVE Loader"
+        android:exported="true"
+        android:enabled="@bool/selector_active"
+        android:theme="@style/Theme.AppCompat.NoActionBar" >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="tv.ouya.intent.category.GAME" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/love/src/normal/java/org/love2d/android/SelectorActivity.java
+++ b/love/src/normal/java/org/love2d/android/SelectorActivity.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2006-2023 LOVE Development Team
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty.  In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ **/
+
+package org.love2d.android;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class SelectorActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (android.os.Build.VERSION.SDK_INT < 19) {
+            Toast.makeText(this, "This activity does not work on Android before KitKat!", Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
+        final ActivityResultLauncher<String[]> openFileLauncher = registerForActivityResult(
+            new ActivityResultContracts.OpenDocument(),
+            (Uri result) -> {
+                if (result != null) {
+                    Intent intent = new Intent(SelectorActivity.this, GameActivity.class);
+                    intent.setData(result);
+                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                    startActivity(intent);
+                }
+
+                SelectorActivity.this.finish();
+            }
+        );
+
+        openFileLauncher.launch(new String[] {"*/*"});
+    }
+}

--- a/love/src/normal/res/values-v19/bools.xml
+++ b/love/src/normal/res/values-v19/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="selector_active">true</bool>
+</resources>

--- a/love/src/normal/res/values/bools.xml
+++ b/love/src/normal/res/values/bools.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <bool name="embed">false</bool>
+    <bool name="selector_active">false</bool>
 </resources>


### PR DESCRIPTION
After looking through the 12.x code, backporting the game selector would require rewrite to the GameActivity.java, not ideal.

This PR adds another icon in the home screen called "LÖVE Loader" that simply asks for .love file to open and run that. Fixes #248.