### PR TITLE
Fix embedding 

### DIFF
--- a/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/love/src/main/java/org/love2d/android/GameActivity.java
@@ -201,11 +201,6 @@ public class GameActivity extends SDLActivity {
                 alert_dialog.setCancelable(false);
                 alert_dialog.create().show();
             }
-        } else {
-            // No game specified via the intent data or embed build is used.
-            // Load game archive only when needed.
-            needToCopyGameInArchive = embed;
-            gamePath = "";
         }
 
         Log.d("GameActivity", "new gamePath: " + gamePath);

--- a/love/src/main/java/org/love2d/android/GameActivity.java
+++ b/love/src/main/java/org/love2d/android/GameActivity.java
@@ -114,6 +114,7 @@ public class GameActivity extends SDLActivity {
         gamePath = "";
         storagePermissionUnnecessary = false;
         embed = getResources().getBoolean(R.bool.embed);
+        needToCopyGameInArchive = embed;
 
         if (!embed) {
             handleIntent(getIntent());


### PR DESCRIPTION
Fixes #258 

Subtle bug introduced by the fix for #254 means that the code which configures the activity to load the game.love file into the cache is no longer reachable. Thss moves the initialisation of `needToCopyGameInArchive` into `onCreate` and removes the unreachable code from `handleIntent`